### PR TITLE
Caching indices

### DIFF
--- a/examples/single_bcode/analysis/single_bcode.xml
+++ b/examples/single_bcode/analysis/single_bcode.xml
@@ -58,7 +58,7 @@
     </taxa>
 
     <run id="mcmc" spec="MCMC" chainLength="100000">
-        <state id="state" spec="State" storeEvery="1">
+        <state id="state" spec="State" storeEvery="100">
 
 
             <tree id="Tree.t:sciphyTest" spec="beast.base.evolution.tree.Tree" name="stateNode">
@@ -126,7 +126,7 @@
             <!-- Tree likelihood -->
             <distribution id="likelihood" spec="beast.base.inference.CompoundDistribution">
                 <distribution id="treeLikelihood.sciphyTest" spec="sciphy.evolution.likelihood.SciPhyTreeLikelihood" data="@sciphyTest" tree="@Tree.t:sciphyTest" origin="60" useScaling="true" arrayLength="5">
-                    <siteModel id="SiteModel.s:sciphyTest" spec="SiteModel" gammaCategoryCount="2" shape="7.907">
+                    <siteModel id="SiteModel.s:sciphyTest" spec="SiteModel">
                         <parameter id="mutationRate.s:sciphyTest" spec="parameter.RealParameter" estimate="false" name="mutationRate">1.0</parameter>
                         <parameter id="proportionInvariant.s:sciphyTest" spec="parameter.RealParameter" estimate="false" lower="0.0" name="proportionInvariant" upper="1.0">0.0</parameter>
                         <substModel id="submodel.s:sciphyTest" spec="sciphy.evolution.substitutionmodel.SciPhySubstitutionModel" editProbabilities="@editProbs">
@@ -137,6 +137,8 @@
                 </distribution>
             </distribution>
         </distribution>
+
+
 
         <!-- tree operators -->
 

--- a/test/sciphy/SciPhyLikelihoodTest.java
+++ b/test/sciphy/SciPhyLikelihoodTest.java
@@ -289,16 +289,16 @@ public class SciPhyLikelihoodTest {
         assertEquals(3, statesDictionary.size());
 
         //1st leaf
-        assertEquals(statesDictionary.get(1).size(), 1);
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 1);
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         //root node
-        assertEquals(statesDictionary.get(6).size(), 1);
-        assertTrue(statesDictionary.get(6).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
     }
 
@@ -356,23 +356,23 @@ public class SciPhyLikelihoodTest {
         assertEquals(3, statesDictionary.size());
 
         //1st leaf
-        assertEquals(statesDictionary.get(1).size(), 4);
-        assertTrue(statesDictionary.get(1).contains(allele123));
-        assertTrue(statesDictionary.get(1).contains(allele12));
-        assertTrue(statesDictionary.get(1).contains(allele1));
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 4);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele123));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 3);
-        assertTrue(statesDictionary.get(2).contains(allele12));
-        assertTrue(statesDictionary.get(2).contains(allele1));
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         //root node
-        assertEquals(statesDictionary.get(6).size(), 3);
-        assertTrue(statesDictionary.get(6).contains(allele12));
-        assertTrue(statesDictionary.get(6).contains(allele1));
-        assertTrue(statesDictionary.get(6).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
 
     }
@@ -433,20 +433,20 @@ public class SciPhyLikelihoodTest {
         assertEquals(3, statesDictionary.size());
 
         //1st leaf
-        assertEquals(statesDictionary.get(1).size(), 3);
-        assertTrue(statesDictionary.get(1).contains(allele12));
-        assertTrue(statesDictionary.get(1).contains(allele1));
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 3);
-        assertTrue(statesDictionary.get(2).contains(allele21));
-        assertTrue(statesDictionary.get(2).contains(allele2));
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele21));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele2));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         //root node
-        assertEquals(statesDictionary.get(6).size(), 1);
-        assertTrue(statesDictionary.get(6).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
 
     }
@@ -508,21 +508,21 @@ public class SciPhyLikelihoodTest {
         assertEquals(3, statesDictionary.size());
 
         //1st leaf
-        assertEquals(statesDictionary.get(1).size(), 3);
-        assertTrue(statesDictionary.get(1).contains(allele12));
-        assertTrue(statesDictionary.get(1).contains(allele1));
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 4);
-        assertTrue(statesDictionary.get(2).contains(allele211));
-        assertTrue(statesDictionary.get(2).contains(allele21));
-        assertTrue(statesDictionary.get(2).contains(allele2));
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 4);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele211));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele21));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele2));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         //root node
-        assertEquals(statesDictionary.get(6).size(), 1);
-        assertTrue(statesDictionary.get(6).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
 
     }
@@ -583,20 +583,20 @@ public class SciPhyLikelihoodTest {
         assertEquals(3, statesDictionary.size());
 
         //1st leaf
-        assertEquals(statesDictionary.get(1).size(), 2);
-        assertTrue(statesDictionary.get(1).contains(allele1));
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 2);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 3);
-        assertTrue(statesDictionary.get(2).contains(allele31));
-        assertTrue(statesDictionary.get(2).contains(allele3));
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele31));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele3));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         //root node
-        assertEquals(statesDictionary.get(6).size(), 1);
-        assertTrue(statesDictionary.get(6).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
 
     }
@@ -661,31 +661,31 @@ public class SciPhyLikelihoodTest {
 
         //check the ancestral dictionaries
         //todo find a way to extract node numbers in a way that we know their position in the tree
-        assertEquals(statesDictionary.get(1).size(), 3);
-        assertTrue(statesDictionary.get(1).contains(allele12));
-        assertTrue(statesDictionary.get(1).contains(allele1));
-        assertTrue(statesDictionary.get(1).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(0)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele12));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(0)).contains(allele0));
 
         //2nd leaf
-        assertEquals(statesDictionary.get(2).size(), 3);
-        assertTrue(statesDictionary.get(2).contains(allele11));
-        assertTrue(statesDictionary.get(2).contains(allele1));
-        assertTrue(statesDictionary.get(2).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(1)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele11));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(1)).contains(allele0));
 
         // node c
-        assertEquals(statesDictionary.get(3).size(), 3);
-        assertTrue(statesDictionary.get(3).contains(allele21));
-        assertTrue(statesDictionary.get(3).contains(allele2));
-        assertTrue(statesDictionary.get(3).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(2)).size(), 3);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele21));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele2));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(2)).contains(allele0));
 
         //internal node between a and b
-        assertEquals(statesDictionary.get(8).size(), 2);
-        assertTrue(statesDictionary.get(8).contains(allele1));
-        assertTrue(statesDictionary.get(8).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(3)).size(), 2);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(3)).contains(allele1));
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(3)).contains(allele0));
 
         //root node a/b/c
-        assertEquals(statesDictionary.get(10).size(), 1);
-        assertTrue(statesDictionary.get(10).contains(allele0));
+        assertEquals(statesDictionary.get(likelihood.makeCachingIndexStates(4)).size(), 1);
+        assertTrue(statesDictionary.get(likelihood.makeCachingIndexStates(4)).contains(allele0));
 
 
     }


### PR DESCRIPTION
Consistent use of hashcode as caching indices for ancestral states + correct example script